### PR TITLE
Improve category deletion UX and ordering

### DIFF
--- a/lib/features/contracts/data/app_state.dart
+++ b/lib/features/contracts/data/app_state.dart
@@ -64,7 +64,12 @@ class AppState extends ChangeNotifier {
 
   String addCategory(String name) {
     final id = 'cat_${DateTime.now().microsecondsSinceEpoch}';
-    _categories.add(ContractGroup(id: id, name: name, builtIn: false));
+    final otherIndex = _categories.indexWhere((c) => c.id == 'cat_other');
+    final insertAt = otherIndex == -1 ? _categories.length : otherIndex;
+    _categories.insert(
+      insertAt,
+      ContractGroup(id: id, name: name, builtIn: false),
+    );
     notifyListeners();
     return id;
   }
@@ -78,13 +83,14 @@ class AppState extends ChangeNotifier {
     }
   }
 
-  void deleteCategory(String id) {
-    if (_categories.any((c) => c.id == id && c.builtIn)) return; // keep defaults
-    // move contracts to "Other" when their group is deleted
-    for (final c in _contracts.where((c) => c.categoryId == id).toList()) {
+  int deleteCategory(String id) {
+    if (_categories.any((c) => c.id == id && c.builtIn)) return 0; // keep defaults
+    final moved = _contracts.where((c) => c.categoryId == id).toList();
+    for (final c in moved) {
       updateContract(c.copyWith(categoryId: 'cat_other'));
     }
     _categories.removeWhere((c) => c.id == id);
     notifyListeners();
+    return moved.length;
   }
 }


### PR DESCRIPTION
## Summary
- Ensure custom categories are inserted before `Other`
- Allow deleting categories via long-press on chips in contract edit and main pages
- Show dismissible notification listing contracts moved to `Other`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac41e1a7d08329ae5a4975fd58f5c0