### PR TITLE
Implement contract end flow and trash management

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -4,7 +4,6 @@ import '../features/overview/presentation/overview_page.dart';
 import '../features/contracts/presentation/contracts_page.dart';
 import '../features/contracts/presentation/contract_view.dart';
 import '../features/contracts/presentation/contract_edit_page.dart';
-import '../features/reminders/presentation/reminders_page.dart';
 import '../features/profile/presentation/profile_page.dart';
 import '../features/contracts/domain/models.dart';
 import 'routes.dart';
@@ -46,10 +45,6 @@ final router = GoRouter(
               },
             ),
           ],
-        ),
-        GoRoute(
-          path: AppRoutes.reminders,
-          builder: (_, __) => RemindersPage(state: appState),
         ),
         GoRoute(
           path: AppRoutes.profile,

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -1,8 +1,7 @@
 class AppRoutes {
   static const overview = '/';
   static const contracts = '/contracts';
-  static const reminders = '/reminders';
-  static const profile = '/profile';
+    static const profile = '/profile';
 
   static const contractNew = '/contracts/new';
   static String contractDetails(String id) => '/contracts/$id';

--- a/lib/app/shell.dart
+++ b/lib/app/shell.dart
@@ -8,51 +8,44 @@ class HomeShell extends StatelessWidget {
   final Widget child; // current routed page
   const HomeShell({super.key, required this.state, required this.child});
 
-  int _indexFromLocation(String loc) {
-    if (loc.startsWith(AppRoutes.contracts)) return 1;
-    if (loc.startsWith(AppRoutes.reminders)) return 2;
-    if (loc.startsWith(AppRoutes.profile)) return 3;
-    return 0; // overview default
+    int _indexFromLocation(String loc) {
+      if (loc.startsWith(AppRoutes.contracts)) return 1;
+      if (loc.startsWith(AppRoutes.profile)) return 2;
+      return 0; // overview default
     }
 
   @override
   Widget build(BuildContext context) {
     final loc = GoRouterState.of(context).uri.toString();
     final idx = _indexFromLocation(loc);
-    final paths = const [
-      AppRoutes.overview,
-      AppRoutes.contracts,
-      AppRoutes.reminders,
-      AppRoutes.profile,
-    ];
+      final paths = const [
+        AppRoutes.overview,
+        AppRoutes.contracts,
+        AppRoutes.profile,
+      ];
 
     return Scaffold(
       body: SafeArea(child: child),
       bottomNavigationBar: NavigationBar(
         selectedIndex: idx,
         onDestinationSelected: (i) => context.go(paths[i]),
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.dashboard_outlined),
-            selectedIcon: Icon(Icons.dashboard),
-            label: 'Overview',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.description_outlined),
-            selectedIcon: Icon(Icons.description),
-            label: 'Contracts',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.notifications_active_outlined),
-            selectedIcon: Icon(Icons.notifications_active),
-            label: 'Reminders',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline),
-            selectedIcon: Icon(Icons.person),
-            label: 'Profile',
-          ),
-        ],
+          destinations: const [
+            NavigationDestination(
+              icon: Icon(Icons.dashboard_outlined),
+              selectedIcon: Icon(Icons.dashboard),
+              label: 'Overview',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.description_outlined),
+              selectedIcon: Icon(Icons.description),
+              label: 'Contracts',
+            ),
+            NavigationDestination(
+              icon: Icon(Icons.person_outline),
+              selectedIcon: Icon(Icons.person),
+              label: 'Profile',
+            ),
+          ],
       ),
     );
   }

--- a/lib/features/contracts/data/app_state.dart
+++ b/lib/features/contracts/data/app_state.dart
@@ -37,7 +37,10 @@ class AppState extends ChangeNotifier {
 
   // READ
   List<ContractGroup> get categories => List.unmodifiable(_categories);
-  List<Contract> get contracts => List.unmodifiable(_contracts);
+  List<Contract> get contracts =>
+      List.unmodifiable(_contracts.where((c) => !c.isDeleted));
+  List<Contract> get trashedContracts =>
+      List.unmodifiable(_contracts.where((c) => c.isDeleted));
   ContractGroup? categoryById(String id) => _categories.firstWhere(
         (c) => c.id == id,
         orElse: () => const ContractGroup(id: 'cat_other', name: 'Other', builtIn: true),
@@ -57,8 +60,22 @@ class AppState extends ChangeNotifier {
     }
   }
 
-  void removeContract(String id) {
+  void deleteContract(String id) {
+    final i = _contracts.indexWhere((e) => e.id == id);
+    if (i != -1) {
+      final c = _contracts[i];
+      _contracts[i] = c.copyWith(isActive: false, isDeleted: true);
+      notifyListeners();
+    }
+  }
+
+  void purgeContract(String id) {
     _contracts.removeWhere((e) => e.id == id);
+    notifyListeners();
+  }
+
+  void purgeAll() {
+    _contracts.removeWhere((e) => e.isDeleted);
     notifyListeners();
   }
 

--- a/lib/features/contracts/data/contracts_repo_memory.dart
+++ b/lib/features/contracts/data/contracts_repo_memory.dart
@@ -21,24 +21,26 @@ class ContractsRepoMemory implements ContractsRepo {
   Future<String> add(Contract c) async {
     final id = _uuid.v4();
     _items.add(
-      Contract(
-        id: id,
-        title: c.title,
-        provider: c.provider,
-        categoryId: c.categoryId,
-        costAmount: c.costAmount,
-        costCurrency: c.costCurrency,
-        billingCycle: c.billingCycle,
-        paymentMethod: c.paymentMethod,
-        paymentNote: c.paymentNote,
-        startDate: c.startDate,
-        endDate: c.endDate,
-        isOpenEnded: c.isOpenEnded,
-      ),
-    );
-    _emit();
-    return id;
-  }
+        Contract(
+          id: id,
+          title: c.title,
+          provider: c.provider,
+          categoryId: c.categoryId,
+          costAmount: c.costAmount,
+          costCurrency: c.costCurrency,
+          billingCycle: c.billingCycle,
+          paymentMethod: c.paymentMethod,
+          paymentNote: c.paymentNote,
+          startDate: c.startDate,
+          endDate: c.endDate,
+          isOpenEnded: c.isOpenEnded,
+          isActive: c.isActive,
+          isDeleted: c.isDeleted,
+        ),
+      );
+      _emit();
+      return id;
+    }
 
   @override
   Future<void> update(Contract c) async {
@@ -49,8 +51,12 @@ class ContractsRepoMemory implements ContractsRepo {
 
   @override
   Future<void> delete(String id) async {
-    _items.removeWhere((e) => e.id == id);
-    _emit();
+    final i = _items.indexWhere((e) => e.id == id);
+    if (i != -1) {
+      final c = _items[i];
+      _items[i] = c.copyWith(isActive: false, isDeleted: true);
+      _emit();
+    }
   }
 
   @override

--- a/lib/features/contracts/domain/models.dart
+++ b/lib/features/contracts/domain/models.dart
@@ -59,6 +59,8 @@ class Contract {
   final DateTime? startDate;
   final DateTime? endDate;
   final bool isOpenEnded;
+  final bool isActive;
+  final bool isDeleted;
 
   const Contract({
     required this.id,
@@ -73,6 +75,8 @@ class Contract {
     this.startDate,
     this.endDate,
     this.isOpenEnded = false,
+    this.isActive = true,
+    this.isDeleted = false,
   });
 
   bool get isExpired =>
@@ -90,6 +94,8 @@ class Contract {
     DateTime? startDate,
     DateTime? endDate,
     bool? isOpenEnded,
+    bool? isActive,
+    bool? isDeleted,
   }) {
     return Contract(
       id: id,
@@ -104,6 +110,8 @@ class Contract {
       startDate: startDate ?? this.startDate,
       endDate: endDate ?? this.endDate,
       isOpenEnded: isOpenEnded ?? this.isOpenEnded,
+      isActive: isActive ?? this.isActive,
+      isDeleted: isDeleted ?? this.isDeleted,
     );
   }
 }

--- a/lib/features/contracts/presentation/contract_view.dart
+++ b/lib/features/contracts/presentation/contract_view.dart
@@ -36,19 +36,20 @@ class ContractView extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.all(16),
         children: [
-          Row(
-            children: [
-              Chip(
-                label: Text(c.isExpired ? 'Expired' : 'Active'),
-                avatar: Icon(
-                  c.isExpired ? Icons.timer_off_outlined : Icons.check_circle,
-                  size: 18,
+            Row(
+              children: [
+                Chip(
+                  label: Text(c.isActive ? 'Active' : 'Inactive'),
+                  avatar: Icon(
+                    c.isActive ? Icons.check_circle : Icons.close,
+                    size: 18,
+                    color: c.isActive ? null : Colors.red,
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              Text(c.title, style: Theme.of(context).textTheme.titleLarge),
-            ],
-          ),
+                const SizedBox(width: 8),
+                Text(c.title, style: Theme.of(context).textTheme.titleLarge),
+              ],
+            ),
           const SizedBox(height: 12),
 
           // Summary
@@ -109,66 +110,77 @@ class ContractView extends StatelessWidget {
           ),
           const SizedBox(height: 24),
 
-          if (!c.isExpired && !c.isOpenEnded)
-            OutlinedButton.icon(
-              onPressed: () async {
-                final ok = await showDialog<bool>(
-                  context: context,
-                  builder: (_) => AlertDialog(
-                    title: const Text('End contract'),
-                    content: const Text(
-                        'Mark this contract as ended today?'),
-                    actions: [
-                      TextButton(
-                          onPressed: () =>
-                              Navigator.pop(context, false),
-                          child: const Text('Cancel')),
-                      FilledButton(
-                          onPressed: () =>
-                              Navigator.pop(context, true),
-                          child: const Text('End')),
-                    ],
-                  ),
-                );
-                if (ok == true) {
-                  state.updateContract(c.copyWith(endDate: DateTime.now()));
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Contract ended')),
+            if (c.isActive && !c.isDeleted)
+              OutlinedButton.icon(
+                onPressed: () async {
+                  final ok = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('End contract'),
+                      content: const Text('Mark this contract as ended today?'),
+                      actions: [
+                        TextButton(
+                            onPressed: () => Navigator.of(ctx).pop(false),
+                            child: const Text('Cancel')),
+                        FilledButton(
+                            onPressed: () => Navigator.of(ctx).pop(true),
+                            child: const Text('End')),
+                      ],
+                    ),
                   );
-                }
-              },
-              icon: const Icon(Icons.stop_circle_outlined),
-              label: const Text('End contract'),
-            ),
+                  if (ok == true) {
+                    state.updateContract(c.copyWith(
+                        isActive: false, endDate: DateTime.now()));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Contract ended')),
+                    );
+                  }
+                },
+                icon: const Icon(Icons.stop_circle_outlined),
+                label: const Text('End contract'),
+              ),
           const SizedBox(height: 8),
 
-          TextButton.icon(
-            onPressed: () async {
-              final ok = await showDialog<bool>(
-                context: context,
-                builder: (_) => AlertDialog(
-                  title: const Text('Delete contract'),
-                  content: const Text('This cannot be undone.'),
-                  actions: [
-                    TextButton(
-                        onPressed: () =>
-                            Navigator.pop(context, false),
-                        child: const Text('Cancel')),
-                    FilledButton(
-                        onPressed: () =>
-                            Navigator.pop(context, true),
-                        child: const Text('Delete')),
-                  ],
-                ),
-              );
-              if (ok == true) {
-                state.removeContract(c.id);
-                Navigator.pop(context);
-              }
-            },
-            icon: const Icon(Icons.delete_outline),
-            label: const Text('Delete'),
-          ),
+            if (!c.isDeleted)
+              TextButton.icon(
+                onPressed: () async {
+                  final ok = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('Delete contract'),
+                      content: const Text('This cannot be undone.'),
+                      actions: [
+                        TextButton(
+                            onPressed: () => Navigator.of(ctx).pop(false),
+                            child: const Text('Cancel')),
+                        FilledButton(
+                            onPressed: () => Navigator.of(ctx).pop(true),
+                            child: const Text('Delete')),
+                      ],
+                    ),
+                  );
+                  if (ok == true) {
+                    state.deleteContract(c.id);
+                    final messenger = ScaffoldMessenger.of(context);
+                    Navigator.pop(context);
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: const Text('Deleted Contract moved to Trash'),
+                        duration: const Duration(seconds: 3),
+                        behavior: SnackBarBehavior.floating,
+                        action: SnackBarAction(
+                          label: '✕',
+                          onPressed: () {
+                            messenger.hideCurrentSnackBar();
+                          },
+                        ),
+                      ),
+                    );
+                  }
+                },
+                icon: const Icon(Icons.delete_outline),
+                label: const Text('Delete'),
+              ),
         ],
       ),
     );

--- a/lib/features/contracts/presentation/widgets.dart
+++ b/lib/features/contracts/presentation/widgets.dart
@@ -15,12 +15,16 @@ class ContractTile extends StatelessWidget {
     required this.onDetails,
   });
 
-  @override
-  Widget build(BuildContext context) {
-    final status = contract.isExpired ? 'Expired' : 'Active';
-    final statusColor = contract.isExpired
-        ? Theme.of(context).colorScheme.errorContainer
-        : Theme.of(context).colorScheme.secondaryContainer;
+    @override
+    Widget build(BuildContext context) {
+      final status = contract.isActive
+          ? (contract.isExpired ? 'Expired' : 'Active')
+          : 'Inactive';
+      final statusColor = contract.isActive
+          ? (contract.isExpired
+              ? Theme.of(context).colorScheme.errorContainer
+              : Theme.of(context).colorScheme.secondaryContainer)
+          : Theme.of(context).colorScheme.errorContainer;
 
     return Card(
       child: ListTile(

--- a/lib/features/profile/presentation/data_storage/data_storage_page.dart
+++ b/lib/features/profile/presentation/data_storage/data_storage_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import '../../../contracts/data/app_state.dart';
+import 'trash_view.dart';
+
+class DataStoragePage extends StatelessWidget {
+  final AppState state;
+  const DataStoragePage({super.key, required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 1,
+      child: Column(
+        children: [
+          const TabBar(
+            tabs: [
+              Tab(text: 'Trash / Recently Deleted'),
+            ],
+          ),
+          Expanded(
+            child: TabBarView(
+              physics: const NeverScrollableScrollPhysics(),
+              children: [
+                TrashView(state: state),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/data_storage/trash_view.dart
+++ b/lib/features/profile/presentation/data_storage/trash_view.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import '../../../contracts/data/app_state.dart';
+
+class TrashView extends StatefulWidget {
+  final AppState state;
+  const TrashView({super.key, required this.state});
+
+  @override
+  State<TrashView> createState() => _TrashViewState();
+}
+
+class _TrashViewState extends State<TrashView> {
+  final _q = TextEditingController();
+
+  @override
+  void dispose() {
+    _q.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: widget.state,
+      builder: (context, _) {
+        final all = widget.state.trashedContracts;
+        final query = _q.text.trim().toLowerCase();
+        final filtered = all.where((c) {
+          final matchQ = query.isEmpty ||
+              c.title.toLowerCase().contains(query) ||
+              c.provider.toLowerCase().contains(query);
+          return matchQ;
+        }).toList();
+        return Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _q,
+                      onChanged: (_) => setState(() {}),
+                      decoration: const InputDecoration(
+                        hintText: 'Search deleted contracts…',
+                        prefixIcon: Icon(Icons.search),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: all.isEmpty
+                        ? null
+                        : () async {
+                            final ok = await showDialog<bool>(
+                              context: context,
+                              builder: (_) => AlertDialog(
+                                title: const Text('Empty trash?'),
+                                content: const Text(
+                                    'Permanently delete all trashed contracts?'),
+                                actions: [
+                                  TextButton(
+                                      onPressed: () =>
+                                          Navigator.pop(context, false),
+                                      child: const Text('Cancel')),
+                                  FilledButton(
+                                      onPressed: () =>
+                                          Navigator.pop(context, true),
+                                      child: const Text('Delete')),
+                                ],
+                              ),
+                            );
+                            if (ok == true) {
+                              widget.state.purgeAll();
+                            }
+                          },
+                    child: const Text('Delete all'),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: ListView.separated(
+                itemCount: filtered.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (_, i) {
+                  final c = filtered[i];
+                  return ListTile(
+                    title: Text(c.title),
+                    subtitle: Text(c.provider),
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/profile/presentation/profile_page.dart
+++ b/lib/features/profile/presentation/profile_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import '../../contracts/data/app_state.dart';
+import 'views/user_info_view.dart';
+import 'views/notifications_view.dart';
+import 'views/privacy_view.dart';
+import 'data_storage/data_storage_page.dart';
 
 class ProfilePage extends StatelessWidget {
   final AppState state;
@@ -7,12 +11,46 @@ class ProfilePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Profile')),
-      body: const Center(
-        child: Padding(
-          padding: EdgeInsets.all(24),
-          child: Text('User settings, legal, help, and logout (coming soon)'),
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Profile'),
+          bottom: const TabBar(
+            isScrollable: true,
+            tabs: [
+              Tab(text: 'User Info'),
+              Tab(text: 'Notifications & Reminders'),
+              Tab(text: 'Privacy'),
+              Tab(text: 'Data & Storage'),
+            ],
+          ),
+        ),
+        body: Column(
+          children: [
+            Expanded(
+              child: TabBarView(
+                physics: const NeverScrollableScrollPhysics(),
+                children: [
+                  const UserInfoView(),
+                  const NotificationsView(),
+                  const PrivacyView(),
+                  DataStoragePage(state: state),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            ListTile(
+              leading: const Icon(Icons.help_outline),
+              title: const Text('Help & Feedback'),
+              onTap: () {},
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Logout'),
+              onTap: () {},
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/profile/presentation/views/notifications_view.dart
+++ b/lib/features/profile/presentation/views/notifications_view.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class NotificationsView extends StatelessWidget {
+  const NotificationsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Notifications & Reminders (coming soon)'),
+    );
+  }
+}

--- a/lib/features/profile/presentation/views/privacy_view.dart
+++ b/lib/features/profile/presentation/views/privacy_view.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class PrivacyView extends StatelessWidget {
+  const PrivacyView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('Privacy (coming soon)'),
+    );
+  }
+}

--- a/lib/features/profile/presentation/views/user_info_view.dart
+++ b/lib/features/profile/presentation/views/user_info_view.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class UserInfoView extends StatelessWidget {
+  const UserInfoView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('User Info (coming soon)'),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add active/deleted flags to contracts and support soft delete
- confirm contract ending, mark inactive, show delete snackbar and move to trash
- remove reminders nav tab and create profile tabs with Data & Storage trash view
- ensure dialogs close on action and profile tabs don't swipe

## Testing
- ⚠️ `flutter analyze` *(flutter not installed)*
- ⚠️ `flutter test` *(flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5862f08c8329bb60a74352f0779f