### PR TITLE
Improve profile navigation and trash management

### DIFF
--- a/lib/features/contracts/presentation/contract_view.dart
+++ b/lib/features/contracts/presentation/contract_view.dart
@@ -20,17 +20,18 @@ class ContractView extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Contract'),
         actions: [
-          IconButton(
-            tooltip: 'Edit',
-            icon: const Icon(Icons.edit_outlined),
-            onPressed: () async {
-              final updated = await context.push<Contract>(
-                r.AppRoutes.contractNew,
-                extra: c, // pass the current contract to edit
-              );
-              if (updated != null) state.updateContract(updated);
-            },
-          ),
+          if (!c.isDeleted)
+            IconButton(
+              tooltip: 'Edit',
+              icon: const Icon(Icons.edit_outlined),
+              onPressed: () async {
+                final updated = await context.push<Contract>(
+                  r.AppRoutes.contractNew,
+                  extra: c, // pass the current contract to edit
+                );
+                if (updated != null) state.updateContract(updated);
+              },
+            ),
         ],
       ),
       body: ListView(

--- a/lib/features/profile/presentation/data_storage/trash_view.dart
+++ b/lib/features/profile/presentation/data_storage/trash_view.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../../../contracts/data/app_state.dart';
+import '../../../contracts/presentation/widgets.dart';
+import '../../../../app/routes.dart' as r;
 
 class TrashView extends StatefulWidget {
   final AppState state;
@@ -71,7 +74,9 @@ class _TrashViewState extends State<TrashView> {
                               ),
                             );
                             if (ok == true) {
+                              if (!mounted) return;
                               widget.state.purgeAll();
+                              setState(() {});
                             }
                           },
                     child: const Text('Delete all'),
@@ -80,17 +85,24 @@ class _TrashViewState extends State<TrashView> {
               ),
             ),
             Expanded(
-              child: ListView.separated(
-                itemCount: filtered.length,
-                separatorBuilder: (_, __) => const Divider(height: 1),
-                itemBuilder: (_, i) {
-                  final c = filtered[i];
-                  return ListTile(
-                    title: Text(c.title),
-                    subtitle: Text(c.provider),
-                  );
-                },
-              ),
+              child: filtered.isEmpty
+                  ? const Center(child: Text('No trashed contracts'))
+                  : ListView.separated(
+                      padding: const EdgeInsets.all(12),
+                      itemCount: filtered.length,
+                      separatorBuilder: (_, __) => const SizedBox(height: 8),
+                      itemBuilder: (_, i) {
+                        final c = filtered[i];
+                        final cat =
+                            widget.state.categoryById(c.categoryId)!;
+                        return ContractTile(
+                          contract: c,
+                          category: cat,
+                          onDetails: () =>
+                              context.push(r.AppRoutes.contractDetails(c.id)),
+                        );
+                      },
+                    ),
             ),
           ],
         );

--- a/lib/features/profile/presentation/profile_page.dart
+++ b/lib/features/profile/presentation/profile_page.dart
@@ -16,18 +16,18 @@ class ProfilePage extends StatelessWidget {
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Profile'),
-          bottom: const TabBar(
-            isScrollable: true,
-            tabs: [
-              Tab(text: 'User Info'),
-              Tab(text: 'Notifications & Reminders'),
-              Tab(text: 'Privacy'),
-              Tab(text: 'Data & Storage'),
-            ],
-          ),
         ),
         body: Column(
           children: [
+            const TabBar(
+              isScrollable: true,
+              tabs: [
+                Tab(text: 'User Info'),
+                Tab(text: 'Notifications & Reminders'),
+                Tab(text: 'Privacy'),
+                Tab(text: 'Data & Storage'),
+              ],
+            ),
             Expanded(
               child: TabBarView(
                 physics: const NeverScrollableScrollPhysics(),


### PR DESCRIPTION
## Summary
- display profile sections in a horizontal tab bar
- show trashed contracts as cards and disable editing of deleted items
- ensure delete-all trash action clears contracts without crashes

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac66137ccc8329837941c4e18305b6